### PR TITLE
support disabling session timeout.

### DIFF
--- a/cpp/src/jubatus/msgpack/rpc/future_impl.h
+++ b/cpp/src/jubatus/msgpack/rpc/future_impl.h
@@ -63,12 +63,10 @@ public:
 
 	bool step_timeout()
 	{
-		if(m_timeout > 0) {
-			--m_timeout;
-			return false;
-		} else {
-			return true;
-		}
+		if(m_timeout == 0) return false;
+
+		--m_timeout;
+		if(m_timeout == 0) return true; else return false;
 	}
 
         void cancel();


### PR DESCRIPTION
- changed: session::set_timeout(0) will disable session timeout
- fixed: session timeout will invoke in _just_ given seconds.
  ( originally, it invokes in given seconds +1 )
- related: https://github.com/jubatus/jubatus/issues/330
