### PR TITLE
add remove_session method to session_pool

### DIFF
--- a/cpp/src/jubatus/msgpack/rpc/session.h
+++ b/cpp/src/jubatus/msgpack/rpc/session.h
@@ -46,6 +46,11 @@ public:
         void open();
         void close();
 
+	inline bool operator== (const session& o) const
+	{
+		return m_pimpl == o.m_pimpl;
+	}
+
 protected:
 	template <typename Method, typename Parameter>
 	future send_request(Method method,

--- a/cpp/src/jubatus/msgpack/rpc/session_pool.cc
+++ b/cpp/src/jubatus/msgpack/rpc/session_pool.cc
@@ -80,6 +80,18 @@ session session_pool_impl::get_session(const address& addr)
 	return session(s);
 }
 
+void session_pool_impl::remove_session(const session& sess)
+{
+	table_ref ref(m_table);
+	for(table_t::iterator it(ref->begin()); it != ref->end(); ++it) {
+		if (session(it->second.session) == sess) {
+			ref->erase(it);
+			return;
+		}
+	}
+	return;
+}
+
 void session_pool_impl::step_timeout()
 {
 	std::vector<shared_future> timedout;
@@ -148,6 +160,9 @@ session_pool::~session_pool() { }
 
 session session_pool::get_session(const address& addr)
 	{ return m_pimpl->get_session(addr); }
+
+void session_pool::remove_session(const session& sess)
+	{ m_pimpl->remove_session(sess); }
 
 const loop& session_pool::get_loop() const
 	{ return const_cast<const session_pool_impl*>(m_pimpl.get())->get_loop(); }

--- a/cpp/src/jubatus/msgpack/rpc/session_pool.h
+++ b/cpp/src/jubatus/msgpack/rpc/session_pool.h
@@ -44,6 +44,8 @@ public:
 	session get_session(const std::string& host, uint16_t port)
 		{ return get_session(ip_address(host, port)); }
 
+	void remove_session(const session& sess);
+
 	const loop& get_loop() const;
 	loop get_loop();
 

--- a/cpp/src/jubatus/msgpack/rpc/session_pool_impl.h
+++ b/cpp/src/jubatus/msgpack/rpc/session_pool_impl.h
@@ -38,6 +38,8 @@ public:
 	session get_session(const std::string& host, uint16_t port)
 		{ return get_session(ip_address(host, port)); }
 
+	void remove_session(const session& sess);
+
 	loop get_loop()
 		{ return m_loop; }
 


### PR DESCRIPTION
This patch adds feature to remove the specific session from MessagePack-RPC session_pool.
This feature is needed to fix #6.
